### PR TITLE
Forge/1.17: Fix `Clicked` debug message in console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '3.0'
+version = '3.0.1'
 group = 'xyz.rongmario' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'cleancut'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210702220150+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/xyz/rongmario/cleancut/CleanCut.java
+++ b/src/main/java/xyz/rongmario/cleancut/CleanCut.java
@@ -26,7 +26,6 @@ public class CleanCut {
 
     @SuppressWarnings("ConstantConditions")
     private void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        System.out.println("Clicked");
         Level world = event.getWorld();
         if (!world.isClientSide) {
             return;


### PR DESCRIPTION
This removes the `Clicked` message that is spammed in console, bumping patch version in the process. Prebuilt jarfile can be found at [https://cocytus.services/cleancut-3.0.1.jar](https://cocytus.services/cleancut-3.0.1.jar)