### PR TITLE
change "environment" to "client"

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "icon": "assets/cleancut/icon.png",
 
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
     "main": [
     ]


### PR DESCRIPTION
This is a client-only mod. So why not change the `"environment"` parameter to `"client"` in `fabric.mod.json` ?