### PR TITLE
Wire up Modrinth and CurseForge publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,20 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+
+      # A jar carries the version from gradle.properties, not the tag. Without
+      # this, tagging v7.0.1 while mod_version still says 7.0.0 publishes 80
+      # files under the old version, and CurseForge files can't be replaced.
+      - name: Check the tag matches mod_version
+        if: github.event_name == 'release'
+        run: |
+          declared=$(sed -n 's/^mod_version[[:space:]]*=[[:space:]]*//p' gradle.properties | tr -d '[:space:]')
+          tagged=${GITHUB_REF_NAME#v}
+          if [ "$declared" != "$tagged" ]; then
+            echo "::error::release ${GITHUB_REF_NAME} would publish mod_version ${declared}; bump gradle.properties or retag"
+            exit 1
+          fi
+
       - id: read
         run: echo "matrix=$(jq -c . .github/targets.json)" >> "$GITHUB_OUTPUT"
 
@@ -31,7 +45,11 @@ jobs:
     strategy:
       # Uploads are independent; one bad target shouldn't cancel the rest.
       fail-fast: false
-      max-parallel: 1
+      # Each job decompiles its own Minecraft, so a target costs minutes, and
+      # there are 80 of them - serial uploads would run most of a day. Four at
+      # a time matches the build workflow's headroom against Maven Central and
+      # stays well inside both platforms' upload rate limits.
+      max-parallel: 4
       matrix:
         target: ${{ fromJson(needs.targets.outputs.matrix) }}
     steps:

--- a/README.md
+++ b/README.md
@@ -154,15 +154,22 @@ Then build it. If an API moved, the compiler will say so, and the fix is another
 
 Releases go to Modrinth and CurseForge from `.github/workflows/publish.yml`,
 driven by [mod-publish-plugin](https://github.com/modmuss50/mod-publish-plugin).
-One-time setup:
+Both are wired up: the project IDs are in `gradle.properties` (`modrinth_id`,
+`curseforge_id`) and the `MODRINTH_TOKEN` and `CURSEFORGE_TOKEN` secrets are set
+on the repository. Clearing an ID makes that platform get skipped rather than
+fail.
 
-1. Put the project IDs in `gradle.properties` (`modrinth_id`, `curseforge_id`).
-   An empty ID makes that platform get skipped rather than fail.
-2. Add `MODRINTH_TOKEN` and `CURSEFORGE_TOKEN` as repository secrets.
+To cut a release:
 
-Publishing a GitHub release then uploads every target, using the release body as
-the changelog. To rehearse it, run the workflow manually with `dry_run` ticked —
-that builds and validates the uploads without sending anything.
+1. Bump `mod_version` in `gradle.properties` and push it.
+2. Run the workflow manually with `dry_run` ticked. That builds and validates
+   every upload without sending anything.
+3. Tag and publish a GitHub release as `v<mod_version>`. The release body
+   becomes the changelog on both platforms.
+
+The tag has to match `mod_version`, and the workflow stops before uploading
+anything if it doesn't — a jar carries the version it was built with, and a
+file published to CurseForge can't be replaced afterwards.
 
 ## License
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,10 @@ mod_homepage = https://www.curseforge.com/minecraft/mc-mods/cleancut
 mod_sources = https://github.com/Rongmario/CleanCut
 mod_issues = https://github.com/Rongmario/CleanCut/issues
 
-# Publishing targets. Fill these in before the first release; an empty slot
-# makes `publishMods` skip that platform instead of failing.
-modrinth_id =
-curseforge_id =
+# Publishing targets. An empty slot makes `publishMods` skip that platform
+# instead of failing. Tokens come from the MODRINTH_TOKEN and CURSEFORGE_TOKEN
+# environment variables, set as repository secrets for the Publish workflow.
+modrinth_id = CCNUnbXG
+curseforge_id = 392805
 
 fabric_loader_version = 0.16.14


### PR DESCRIPTION
Publishing was plumbed but inert — both project IDs were blank, so `publishMods` skipped both platforms on every target.

- `gradle.properties`: `modrinth_id = CCNUnbXG`, `curseforge_id = 392805`. Both checked against the live APIs — they resolve to CleanCut on each platform.
- The `MODRINTH_TOKEN` / `CURSEFORGE_TOKEN` secrets are already set on the repository, and `publish.yml` already passes them through.

Verified with a real dry run (`PUBLISH_DRY_RUN=true`) on `fabric:1.20.1`, `forge:1.20.1` and `neoforge:1.21.1`. `publishMods` now resolves both `publishCurseforge` and `publishModrinth`, with the expected file, display name and version on each.

Two problems this would have hit on the first real release:

**Tag/version mismatch.** A jar carries `mod_version`, not the tag. Tagging `v7.0.1` while `gradle.properties` still said `7.0.0` would publish 80 files as 7.0.0, and a CurseForge file can't be replaced after the fact. The `targets` job now fails the run before any upload if `v<mod_version>` doesn't match the tag. Release-only, so `workflow_dispatch` rehearsals are unaffected.

**Serial uploads.** `max-parallel: 1` across 80 targets, each decompiling its own Minecraft, is most of a day. Now 4 — same headroom the build workflow uses against Maven Central, and inside both platforms' upload rate limits.

README's publishing section rewritten: the setup steps were describing work that's now done.

Not addressed: the Modrinth project is currently tagged fabric/quilt only. Uploading the Forge and NeoForge files tags those automatically, so nothing to do up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)